### PR TITLE
Included shopper_id in option for create shopper token

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -269,6 +269,7 @@ module ActiveMerchant #:nodoc:
         return unless options[:email]
         xml.tag! 'shopper' do
           xml.tag! 'shopperEmailAddress', options[:email]
+          xml.tag! 'authenticatedShopperID', options[:shopper_id] if options[:shopper_id]
         end
       end
 

--- a/test/remote/gateways/remote_worldpay_test.rb
+++ b/test/remote/gateways/remote_worldpay_test.rb
@@ -31,6 +31,20 @@ class RemoteWorldpayTest < Test::Unit::TestCase
     assert_equal 'SUCCESS', response.message
   end
 
+  def test_successful_purchase_with_create_shopper_token
+    @options.merge!(create_token: {}, token_scope: 'shopper', shopper_id: '10-1')
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
+  def test_successful_purchase_with_create_merchant_token
+    @options.merge!(create_token: {}, token_scope: 'merchant')
+    assert response = @gateway.purchase(@amount, @credit_card, @options)
+    assert_success response
+    assert_equal 'SUCCESS', response.message
+  end
+
   def test_failed_purchase
     assert response = @gateway.purchase(@amount, @declined_card, @options)
     assert_failure response

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -468,7 +468,16 @@ class WorldpayTest < Test::Unit::TestCase
     assert_equal scrubbed_transcript, @gateway.scrub(transcript)
   end
 
-  def test_successful_purchase_with_create_token
+  def test_successful_purchase_with_create_shopper_token
+    @options = @options.merge(create_token: {}, token_scope: 'shopper', shopper_id: '10-1')
+    response = stub_comms do
+      @gateway.purchase(@amount, @credit_card, @options)
+    end.respond_with(successful_authorize_with_token_response, successful_capture_response)
+    assert_success response
+    assert_equal '9902019934757792074', response.responses.first.params['payment_token_id']
+  end
+
+  def test_successful_purchase_with_create_merchant_token
     @options = @options.merge(create_token: {}, token_scope: 'merchant')
     response = stub_comms do
       @gateway.purchase(@amount, @credit_card, @options)


### PR DESCRIPTION
No worldpay, para poder criar novos token sem a necessidade de fazer a gestão dos já existentes devemos usar o atributo tokenScope="shopper", e incluir a possibilidade de envio do authenticatedShopperID que é obrigatório no caso de tokenScope="shopper".

Além disso, por recomendação do worldpay, o ideal é gerar os token como shopper e não merchant, pois para eles merchant é vinculado a uso de máquininha.

