### PR TITLE
Implements the saveOnFile functionality for to store customer credit card's

### DIFF
--- a/lib/active_merchant/billing/gateways/maxipago.rb
+++ b/lib/active_merchant/billing/gateways/maxipago.rb
@@ -218,11 +218,10 @@ module ActiveMerchant #:nodoc:
       end
 
       def add_save_on_file(xml, options)
-        customer_token = options[:customer_token]
-        return unless customer_token
+        return unless options[:customer_id]
         xml.saveOnFile do
-          xml.customerToken customer_token
-          xml.onFileEndDate options[:token_expiration] if options[:token_expiration]
+          xml.customerToken options[:customer_id]
+          xml.onFileEndDate options[:token_end_date] if options[:token_end_date]
           xml.onFilePermission options[:token_permission] if options[:token_permission]
           xml.onFileComment options[:token_comment] if options[:token_comment]
           xml.onFileMaxChargeAmount options[:token_max_charge_amount] if options[:token_max_charge_amount]

--- a/lib/active_merchant/billing/gateways/maxipago.rb
+++ b/lib/active_merchant/billing/gateways/maxipago.rb
@@ -166,6 +166,7 @@ module ActiveMerchant #:nodoc:
           add_amount(xml, money, options)
           add_installments(xml, options)
         end
+        add_save_on_file(xml, options)
         add_billing_address(xml, creditcard, options)
       end
 
@@ -214,6 +215,18 @@ module ActiveMerchant #:nodoc:
       def add_order_id(xml, authorization)
         order_id, _ = split_authorization(authorization)
         xml.orderID order_id
+      end
+
+      def add_save_on_file(xml, options)
+        customer_token = options[:customer_token]
+        return unless customer_token
+        xml.saveOnFile do
+          xml.customerToken customer_token
+          xml.onFileEndDate options[:token_expiration] if options[:token_expiration]
+          xml.onFilePermission options[:token_permission] if options[:token_permission]
+          xml.onFileComment options[:token_comment] if options[:token_comment]
+          xml.onFileMaxChargeAmount options[:token_max_charge_amount] if options[:token_max_charge_amount]
+        end
       end
     end
   end

--- a/test/unit/gateways/maxipago_test.rb
+++ b/test/unit/gateways/maxipago_test.rb
@@ -15,8 +15,8 @@ class MaxipagoTest < Test::Unit::TestCase
       :billing_address => address,
       :description => 'Store Purchase',
       :installments => 3,
-      :customer_token => '154676',
-      :expiration_date => '01/01/9999'
+      :customer_id => '154676',
+      :token_end_date => '01/01/9999'
     }
   end
 

--- a/test/unit/gateways/maxipago_test.rb
+++ b/test/unit/gateways/maxipago_test.rb
@@ -3,20 +3,20 @@ require 'test_helper'
 class MaxipagoTest < Test::Unit::TestCase
   def setup
     @gateway = MaxipagoGateway.new(
-      :login => 'login',
-      :password => 'password'
+      login: 'login',
+      password: 'password'
     )
 
     @credit_card = credit_card
     @amount = 100
 
     @options = {
-      :order_id => '1',
-      :billing_address => address,
-      :description => 'Store Purchase',
-      :installments => 3,
-      :customer_id => '154676',
-      :token_end_date => '01/01/9999'
+      order_id: '1',
+      billing_address: address,
+      description: 'Store Purchase',
+      installments: 3,
+      customer_id: '154676',
+      token_end_date: '01/01/9999'
     }
   end
 

--- a/test/unit/gateways/maxipago_test.rb
+++ b/test/unit/gateways/maxipago_test.rb
@@ -14,7 +14,9 @@ class MaxipagoTest < Test::Unit::TestCase
       :order_id => '1',
       :billing_address => address,
       :description => 'Store Purchase',
-      :installments => 3
+      :installments => 3,
+      :customer_token => '154676',
+      :expiration_date => '01/01/9999'
     }
   end
 
@@ -25,6 +27,8 @@ class MaxipagoTest < Test::Unit::TestCase
     assert_success response
 
     assert_equal '123456789|123456789', response.authorization
+    assert_equal 'iZrWy6+PJpQ=', response.params["token"]
+    assert_equal '4242********4242', response.params["credit_card_number"]
   end
 
   def test_failed_purchase
@@ -41,6 +45,9 @@ class MaxipagoTest < Test::Unit::TestCase
     assert_success response
 
     assert_equal 'C0A8013F:014455FCC857:91A0:01A7243E|663921', response.authorization
+    assert_equal 'iZrWy6+PJpQ=', response.params["token"]
+    assert_equal '4242********4242', response.params["credit_card_number"]
+
     assert response.test?
   end
 
@@ -196,6 +203,12 @@ class MaxipagoTest < Test::Unit::TestCase
         <processorTransactionID>123456789</processorTransactionID>
         <processorReferenceNumber>123456789</processorReferenceNumber>
         <fraudScore>29</fraudScore>
+        <creditCardCountry>US</creditCardCountry>
+        <creditCardScheme>Visa</creditCardScheme>
+        <save-on-file>
+          <token>iZrWy6+PJpQ=</token>
+          <creditCardNumber>4242********4242</creditCardNumber>
+        </save-on-file>
       </transaction-response>
     )
   end
@@ -235,6 +248,12 @@ class MaxipagoTest < Test::Unit::TestCase
         <processorCode>A</processorCode>
         <processorMessage>APPROVED</processorMessage>
         <errorMessage/>
+        <creditCardCountry>US</creditCardCountry>
+        <creditCardScheme>Visa</creditCardScheme>
+        <save-on-file>
+          <token>iZrWy6+PJpQ=</token>
+          <creditCardNumber>4242********4242</creditCardNumber>
+        </save-on-file>
       </transaction-response>
     )
   end


### PR DESCRIPTION
## Saving a card during a transaction
It is also possible to store a credit card number automatically during an authorization or sale.

see [documentation](http://www.maxipago.com/docs/maxiPago_API_Latest.pdf) page 75