### PR TITLE
[BILL-4903] feat: add supplementary_id to normalized stored credentials

### DIFF
--- a/lib/active_merchant/billing/gateways/worldpay.rb
+++ b/lib/active_merchant/billing/gateways/worldpay.rb
@@ -292,6 +292,7 @@ module ActiveMerchant #:nodoc:
 
           xml.tag! 'storedCredentials', 'usage' => 'USED', 'merchantInitiatedReason' => reason do
             xml.tag! 'schemeTransactionIdentifier', options[:stored_credential][:network_transaction_id] if options[:stored_credential][:network_transaction_id]
+            xml.tag! 'supplementaryId', options[:stored_credential][:supplementary_id] if options[:stored_credential][:supplementary_id]
           end
         end
       end

--- a/test/unit/gateways/worldpay_test.rb
+++ b/test/unit/gateways/worldpay_test.rb
@@ -80,6 +80,82 @@ class WorldpayTest < Test::Unit::TestCase
     assert_success response
   end
 
+  def test_authorize_passes_stored_credential_normalized_initial
+    options = @options.merge(
+      stored_credential: {
+        initial_transaction: true
+      }
+    )
+    
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match %r(<storedCredentials usage="FIRST"/>), data
+    end.respond_with(successful_authorize_response)
+    
+    assert_success response
+  end
+
+  def test_authorize_passes_stored_credential_normalized_subsequent_installment
+    options = @options.merge(
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'installment',
+        network_transaction_id: '000000000000020005',
+        supplementary_id: '550e8400-e29b-41d4-a716-446655440000'
+      }
+    )
+    
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match %r(<storedCredentials usage="USED" merchantInitiatedReason="INSTALMENT">), data
+      assert_match %r(<schemeTransactionIdentifier>000000000000020005</schemeTransactionIdentifier>), data
+      assert_match %r(<supplementaryId>550e8400-e29b-41d4-a716-446655440000</supplementaryId>), data
+    end.respond_with(successful_authorize_response)
+    
+    assert_success response
+  end
+
+  def test_authorize_passes_stored_credential_normalized_subsequent_recurring
+    options = @options.merge(
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'recurring',
+        network_transaction_id: '000000000000020006'
+      }
+    )
+    
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match %r(<storedCredentials usage="USED" merchantInitiatedReason="RECURRING">), data
+      assert_match %r(<schemeTransactionIdentifier>000000000000020006</schemeTransactionIdentifier>), data
+      assert_no_match %r(supplementaryId), data
+    end.respond_with(successful_authorize_response)
+    
+    assert_success response
+  end
+
+  def test_authorize_passes_stored_credential_normalized_subsequent_unscheduled
+    options = @options.merge(
+      stored_credential: {
+        initial_transaction: false,
+        reason_type: 'unscheduled'
+      }
+    )
+    
+    response = stub_comms do
+      @gateway.authorize(@amount, @credit_card, options)
+    end.check_request do |endpoint, data, headers|
+      assert_match %r(<storedCredentials usage="USED" merchantInitiatedReason="UNSCHEDULED">), data
+      assert_no_match %r(schemeTransactionIdentifier), data
+      assert_no_match %r(supplementaryId), data
+    end.respond_with(successful_authorize_response)
+    
+    assert_success response
+  end
+
   def test_failed_authorize
     response = stub_comms do
       @gateway.authorize(@amount, @credit_card, @options)


### PR DESCRIPTION
## 📌 Problema
O gateway Worldpay em `ActiveMerchant::Billing::Gateways::Worldpay` já suportava credenciais armazenadas normalizadas via `stored_credential`, incluindo `network_transaction_id` (`schemeTransactionIdentifier`), mas não repassava o campo `supplementary_id` para o XML da Worldpay.

Para transações recorrentes com **Mastercard**, a Worldpay exige identificadores adicionais: o **TLID** como `schemeTransactionIdentifier` e o **trace ID** como `supplementaryId`. Sem esse mapeamento no `active_merchant`, o `Domains::Payments::PaymentGateways::Drivers::Worldpay::OptionsConverter` no `saas-internal` não conseguia completar o fluxo de credenciais armazenadas para Mastercard, mesmo já montando `supplementary_id` nas options.

**Impacto:** pagamentos recorrentes Mastercard via Worldpay podiam falhar ou ser rejeitados por falta do `supplementaryId` na requisição.

## 💡 Solução
Adicionado suporte ao campo `supplementary_id` no fluxo de credenciais armazenadas normalizadas do gateway Worldpay:
- Em transações subsequentes (`usage="USED"`), quando `options[:stored_credential][:supplementary_id]` estiver presente, o XML passa a incluir `<supplementaryId>`.
- O campo só é enviado quando presente (comportamento condicional, igual ao `network_transaction_id`).
- Cobertura de testes unitários ampliada para os cenários normalizados de `stored_credential` (initial, installment, recurring e unscheduled).

**Arquivos alterados:**
- `lib/active_merchant/billing/gateways/worldpay.rb`
- `test/unit/gateways/worldpay_test.rb`

**Relacionado:** PR correspondente no `saas-internal` que mapeia TLID/trace para `network_transaction_id`/`supplementary_id` no `OptionsConverter`.

**Dependência:** Nenhuma no código. Requer que `enableTLIDinXML` esteja ativado no ambiente de Staging pela Worldpay para validação end-to-end.

## 🧪 Cenários de Teste
#### Setup
- Ambiente Staging com `saas-internal` apontando para a versão do `active_merchant` deste PR
- Gateway Worldpay configurado e habilitado
- `enableTLIDinXML` ativado no ambiente de Staging pela Worldpay
- Cartão Mastercard tokenizado com histórico de transação anterior (TLID e trace ID disponíveis nos metadados)
#### Cenário 1 — Pagamento recorrente Mastercard com TLID
- **Dado** um pagamento recorrente com cartão Mastercard tokenizado e TLID + trace ID nos metadados
- **Quando** o pagamento é processado via Worldpay
- [ ] **Então** a transação é autorizada com sucesso
- [ ] **Então** a requisição enviada ao gateway inclui `supplementaryId` no bloco `storedCredentials`
#### Cenário 2 — Pagamento recorrente Mastercard sem TLID
- **Dado** um pagamento recorrente com cartão Mastercard tokenizado e apenas trace ID (sem TLID)
- **Quando** o pagamento é processado via Worldpay
- [ ] **Então** a transação é autorizada com sucesso
- [ ] **Então** a requisição inclui `supplementaryId` e não inclui `schemeTransactionIdentifier`
#### Cenário 3 — Pagamento recorrente Visa (regressão)
- **Dado** um pagamento recorrente com cartão Visa tokenizado
- **Quando** o pagamento é processado via Worldpay
- [ ] **Então** a transação continua sendo autorizada normalmente
- [ ] **Então** a requisição **não** inclui `supplementaryId`
#### Cenário 4 — Primeira transação (regressão)
- **Dado** um pagamento com cartão novo (sem token)
- **Quando** o pagamento é processado via Worldpay
- [ ] **Então** a transação é autorizada com sucesso
- [ ] **Então** a requisição usa `storedCredentials` com `usage="FIRST"`
## 🔍 Checklist Pré-Deploy
- [ ] Validar cenários em Staging (conforme seção acima)
- [ ] Confirmar que `enableTLIDinXML` está ativado no Staging pela Worldpay
- [ ] PR correspondente no `saas-internal` mergeado (ou em paralelo) para consumir `supplementary_id`
- [ ] Bump da versão do `active_merchant` no `saas-internal` após merge deste PR
## 📊 Monitoramento Pós-Deploy
- [ ] Validar pagamentos recorrentes Mastercard via Worldpay em Staging
- [ ] Confirmar que requisições subsequentes incluem `supplementaryId` quando aplicável
- [ ] Acompanhar taxa de aprovação/rejeição de transações recorrentes Mastercard no ambiente integrado

 
 **PR Summary by Typo**
------------

#### Visão Geral
Este pull request adiciona suporte à tag `<supplementaryId>` no XML de requisição do gateway Worldpay, permitindo que transações com credenciais armazenadas incluam um identificador suplementar. A mudança visa habilitar a funcionalidade para ser utilizada por outros serviços que dependam dessa gem.

#### Principais Alterações
- Adicionada a tag `supplementaryId` ao XML de `storedCredentials` no gateway Worldpay, que será incluída se a opção `supplementary_id` for fornecida.
- Incluídos novos testes unitários para verificar o comportamento correto da tag `supplementaryId` e outros cenários de credenciais armazenadas (iniciais, parceladas, recorrentes e não agendadas).

#### Work Breakdown

| Categoria     | Lines Changed |
|---------------|---------------|
| New Work      | 77 (100.0%)   |
| Total Changes | 77            |

#### Linked JIRA Issues
[BILL-4903](https://rdstation.atlassian.net/browse/BILL-4903) - Adicionar suporte à tag `<supplementaryId>` no XML de requisição da gem activemerchant para o gateway Worldpay, incluindo testes correspondentes. 

 <h6>To turn off PR summary, please visit <a href="https://app.typoapp.io/settings/notification?tab=codeHealth">Notification settings</a>.</h6>

[BILL-4903]: https://rdstation.atlassian.net/browse/BILL-4903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ